### PR TITLE
Allow plugin to reside in mu-plugins

### DIFF
--- a/class/wpsdb.php
+++ b/class/wpsdb.php
@@ -2206,7 +2206,7 @@ class WPSDB extends WPSDB_Base {
 			$this->download_file();
 		}
 
-		$plugins_url = trailingslashit( plugins_url() ) . trailingslashit( $this->plugin_folder_name );
+		$plugins_url = trailingslashit( plugins_url( '', $this->plugin_file_path ) );
 
 		$version = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ? time() : $this->plugin_version;
 


### PR DESCRIPTION
Previously, this plugin only worked in the /plugins directory. This change makes the .js file location more agnostic to its residence under /plugins or /mu-plugins.