### PR TITLE
Prevent notices in PHP 7.1 that break admin ui

### DIFF
--- a/class/wpsdb.php
+++ b/class/wpsdb.php
@@ -1259,6 +1259,7 @@ class WPSDB extends WPSDB_Base {
 	function get_post_max_size() {
 		$val = trim( ini_get( 'post_max_size' ) );
 		$last = strtolower( $val[ strlen( $val ) - 1 ] );
+		$val = (int) $val;
 		switch ( $last ) {
 		case 'g':
 			$val *= 1024;
@@ -2410,6 +2411,7 @@ class WPSDB extends WPSDB_Base {
 		if( empty( $val ) ) return false;
 		$val = trim($val);
 		$last = strtolower($val[strlen($val)-1]);
+		$val = (int) $val;
 		switch($last) {
 			// The 'G' modifier is available since PHP 5.1.0
 			case 'g':


### PR DESCRIPTION
This is the same thing as https://github.com/wp-sync-db/wp-sync-db/pull/120.

Submitting this near-duplicate just in case the weird commit history, funky indentation, and `.gitignore` addition is the thing blocking the maintainer from merging that PR. This one is clean and lots of folks would be helped out by a merge.

Admin UI is unusable in PHP 7.1 due to php notice. Also initialization may be compromised.  Because `wp-sync-db` is meant to do things like push from dev to staging, this plugin is very often going to be run in an environment where `WP_DEBUG` is (and should be) enabled. So, disabling `WP_DEBUG` is not a viable solution long-term. See https://github.com/wp-sync-db/wp-sync-db/issues/123 and https://github.com/wp-sync-db/wp-sync-db/issues/118.